### PR TITLE
DEVOPS-136 publish versions file and release notes from release branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,3 @@
+include:
+  - project: "openfin/devops/ci"
+    file: "/dotnet-dotnet-fdc3-client.yml"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,1 @@
+# Release Notes


### PR DESCRIPTION
This hooks up to GitLab's CI and will be publishing versions file and release notes for every release branch